### PR TITLE
Use spdx-builder v0.6.0 and ORT version 2021-05-31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Use spdx-builder v0.6.0
+- Use ORT version 2021-05-31
+
+### Release v0.5.0
 - First version

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This action is an `composite` action.
       java-version: '11.0.1'
   - name: Create spdx-file
     id: spdx-builder
-    uses: philips-software/spdx-action@v0.1.1
+    uses: philips-software/spdx-action@v0.6.0
     with:
       project: my-project
   - uses: actions/upload-artifact@v2

--- a/action.yml
+++ b/action.yml
@@ -21,11 +21,11 @@ inputs:
   spdx-builder-version:
     description: "spdx-builder-version"
     required: true
-    default: 'v0.5.0'
+    default: 'v0.6.0'
   ort-version:
     description: "philipssoftware/ort version"
     required: false
-    default: '2021-03-03'
+    default: '2021-05-31'
   ort-file:
     description: "Specifies an ort-file to override ORT scanning in this action."
     required: true


### PR DESCRIPTION
Update versions of tools.

SPDX-builder also supports tree-based input. This is not yet supported in the action.