### PR TITLE
Pass optional arguments to blackduck mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -248,4 +248,5 @@ runs:
         BLACKDUCK_VERSION: ${{ inputs.blackduck-version }}
         BLACKDUCK_URL: ${{ inputs.blackduck-url }}
         BLACKDUCK_TOKEN: ${{ inputs.blackduck-token }}
+        OPTIONAL_ARGUMENTS: ${{ inputs.optional-arguments }}
       shell: bash


### PR DESCRIPTION
# Problem

Optional arguments were not passed to blackduck mode.

## Version
spdx-action version: v0.8.1

## Example
In this workflow the optional arguments are passed but not used in the call to spdx-builder.

https://github.com/philips-internal/swat-sbom-spdx-action-test/runs/4226138946?check_suite_focus=true#step:5:9

<img width="992" alt="Screenshot 2021-11-16 at 16 55 53" src="https://user-images.githubusercontent.com/10019/142019691-c6981dba-9958-483c-bac2-d44105f44dd1.png">

